### PR TITLE
feat: [PIDM-504] update deploy config and strategy

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.35.0
 appVersion: 0.5.4
 dependencies:
   - name: microservice-chart
-    version: 7.5.0
+    version: 8.0.2
     repository: "https://pagopa.github.io/aks-microservice-chart-blueprint"

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -22,8 +22,14 @@ microservice-chart:
     initialDelaySeconds: 90
     failureThreshold: 6
     periodSeconds: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   deployment:
     create: true
+    replicas: 1 # (default) same as HPA minReplica
   service:
     create: true
     type: ClusterIP

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -22,14 +22,14 @@ microservice-chart:
     initialDelaySeconds: 90
     failureThreshold: 6
     periodSeconds: 10
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 0
-      maxSurge: 1
   deployment:
     create: true
     replicas: 1 # (default) same as HPA minReplica
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 0
+        maxSurge: 1
   service:
     create: true
     type: ClusterIP

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -22,8 +22,14 @@ microservice-chart:
     initialDelaySeconds: 90
     failureThreshold: 6
     periodSeconds: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   deployment:
     create: true
+    replicas: 1 # same as HPA minReplica
   service:
     create: true
     type: ClusterIP

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -22,14 +22,14 @@ microservice-chart:
     initialDelaySeconds: 90
     failureThreshold: 6
     periodSeconds: 10
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 0
-      maxSurge: 1
   deployment:
     create: true
     replicas: 1 # same as HPA minReplica
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 0
+        maxSurge: 1
   service:
     create: true
     type: ClusterIP

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -22,8 +22,14 @@ microservice-chart:
     initialDelaySeconds: 90
     failureThreshold: 6
     periodSeconds: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   deployment:
     create: true
+    replicas: 1 # (default) same as HPA minReplica
   service:
     create: true
     type: ClusterIP

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -22,14 +22,14 @@ microservice-chart:
     initialDelaySeconds: 90
     failureThreshold: 6
     periodSeconds: 10
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 0
-      maxSurge: 1
   deployment:
     create: true
     replicas: 1 # (default) same as HPA minReplica
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 0
+        maxSurge: 1
   service:
     create: true
     type: ClusterIP


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- upgraded helm chart to v8.0.2
- added rolling update strategy (maxUnavailable, maxSurge)
- overridden deployment replicas to match HPA minReplica config

NOTE: upgraded in

- DEV -> OK
- UAT -> OK
- PROD -> OK

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This upgrade was required to address an issue with the rollout strategy and the autoscaler behaviour, where the pods would scale down to 1 during deploy instead of keeping the same number of pods and doing +1 -1 to avoid traffic congestion. Also replicas are set to match the autoscaling config during deploy, to avoid starting the service with 1 pod when there is relevant traffic on the service.
This also ensures zero-downtime deployments by keeping all existing pods running until new versions are healthy and ready, then replacing them one at a time.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

```
❯ helm upgrade --namespace gps \
    --install --values ./helm/values-dev.yaml \
    --set microservice-chart.azure.workloadIdentityClientId=8a7f62fa-6865-4fc0-a774-337e3982d20f \
    --set microservice-chart.podAnnotations.force-rollout="rollout-$(date +%s)" \
    --wait --timeout 15m0s \
    pagopagpdingestionmanager ./helm
Release "pagopagpdingestionmanager" has been upgraded. Happy Helming!
NAME: pagopagpdingestionmanager
LAST DEPLOYED: Tue Oct 14 12:27:58 2025
NAMESPACE: gps
STATUS: deployed
REVISION: 4
TEST SUITE: None
```

```
❯ kubectl get scaledobject pagopa-gpd-ingestion-manager -n gps -o jsonpath='{.metadata.labels.helm\.sh/blueprint-version}'
7.5.0          -> we need to delete and recreate the scaled object in this case
```

```
❯ kubectl delete scaledobject pagopa-gpd-ingestion-manager -n gps
scaledobject.keda.sh "pagopa-gpd-ingestion-manager" deleted from gps namespace
```

```
❯ helm upgrade --namespace gps \
    --install --values ./helm/values-dev.yaml \
    --set microservice-chart.azure.workloadIdentityClientId=8a7f62fa-6865-4fc0-a774-337e3982d20f \
    --set microservice-chart.podAnnotations.force-rollout="rollout-$(date +%s)" \
    --wait --timeout 15m0s \
    pagopagpdingestionmanager ./helm
Release "pagopagpdingestionmanager" has been upgraded. Happy Helming!
NAME: pagopagpdingestionmanager
LAST DEPLOYED: Tue Oct 14 12:38:04 2025
NAMESPACE: gps
STATUS: deployed
REVISION: 6
TEST SUITE: None
```

```
❯ kubectl get scaledobject pagopa-gpd-ingestion-manager -n gps -o jsonpath='{.metadata.labels.helm\.sh/blueprint-version}'
8.0.2%
```

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.